### PR TITLE
Fix indentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ all: build_muslc
 ifeq (${CONFIG_USER_DEBUG_BUILD},y)
     ENABLE_DEBUG = --enable-debug
 else
-	ENABLE_DEBUG =
+    ENABLE_DEBUG =
 endif
 
 ifeq (${CONFIG_ARCH_IA32},y)


### PR DESCRIPTION
because line 23 begins with a tab make gets confused and things it's a command

```
make[1]: ENABLE_DEBUG: Command not found
make[1]: *** [repo/libs/libmuslc/Makefile:23: all] Error 127
make: *** [tools/common/project.mk:312: libmuslc] Error 2
```