### PR TITLE
make libc_set_threaded() return void

### DIFF
--- a/src/env/__init_tls.c
+++ b/src/env/__init_tls.c
@@ -35,7 +35,7 @@ size_t libc_get_tls_size()
     return libc.tls_size;
 }
 
-int libc_set_threaded(void) {
+void libc_set_threaded(void) {
 	/// Once set, does not get unset.
 	a_store(&libc.threaded, 1);
 }


### PR DESCRIPTION
Fix compilation failure that libc_set_threaded() does not return any value. Make it not return anything at all for now, as it is not supposed to fail.