### PR TITLE
CMake: Suppress build output by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,9 @@ add_custom_command(
     COMMAND
         ${CMAKE_COMMAND} -E env TOOLPREFIX=${CROSS_COMPILER_PREFIX}
         # TODO: should also pass in the cflags for the CMAKE_BUILD_TYPE ?
+        # Suppress make output by default. Verbose make output can now be achieved
+        # by MAKEFLAGS=V3 ninja (${MAKEFLAGS:--s} expands to -s if MAKEFLAGS is unset).
+        "MAKEFLAGS=\$\${MAKEFLAGS:--s}"
         NK_CFLAGS="${compile_options}" TARGET=${muslc_arch} make -C build-temp ${parallel} -f
         "${CMAKE_CURRENT_SOURCE_DIR}/Makefile"
         "STAGE_DIR=${CMAKE_CURRENT_BINARY_DIR}/build-temp/stage"

--- a/Makefile
+++ b/Makefile
@@ -65,10 +65,10 @@ build_muslc:
 		$(MAKE) CFLAGS="${CFLAGS}" CC="${CC}" CROSS_COMPILE="${CROSS_COMPILE}" -f Makefile.muslc clean || true
 
 	# If the configure line did change (or we don't have one yet) then we also need to (re)run configure
-	# Send everything to /dev/null though as configure is quite noisy
+	# Only print output if there's an error as configure is quite noisy
 	# Also need to update the ARCH in the config.mak file configure generates
 	[ "`cat configure_line 2>&1`" != "${configure_line}" ] && \
-		${SOURCE_DIR}/configure ${configure_line} && sed -ibak 's/^ARCH = \(.*\)/ARCH = \1_sel4/' config.mak || true
+		${SOURCE_DIR}/configure ${configure_line} 2>&1 > config.log || cat config.log  && sed -ibak 's/^ARCH = \(.*\)/ARCH = \1_sel4/' config.mak || true
 	# Store the current configuration
 	echo "${configure_line}" > configure_line
 	# Symlink in the correct Makefile as the configure script doesn't know that we renamed the muslc one


### PR DESCRIPTION
- We set MAKEFLAGS=-s by default which suppresses build output for build
rules. If ninja is invoked with MAKEFLAGS=V=3 then this will provide
verbose output.
- Only output output from ./configure if it exits with an error.