### PR TITLE
musllibc: fix restrict violation warnings

### DIFF
--- a/src/aio/lio_listio.c
+++ b/src/aio/lio_listio.c
@@ -114,7 +114,7 @@ int lio_listio(int mode, struct aiocb *restrict const *restrict cbs, int cnt, st
 
 	if (st) {
 		pthread_attr_t a;
-		sigset_t set;
+		sigset_t set, set_old;
 		pthread_t td;
 
 		if (sev->sigev_notify == SIGEV_THREAD) {
@@ -129,13 +129,13 @@ int lio_listio(int mode, struct aiocb *restrict const *restrict cbs, int cnt, st
 		}
 		pthread_attr_setdetachstate(&a, PTHREAD_CREATE_DETACHED);
 		sigfillset(&set);
-		pthread_sigmask(SIG_BLOCK, &set, &set);
+		pthread_sigmask(SIG_BLOCK, &set, &set_old);
 		if (pthread_create(&td, &a, wait_thread, st)) {
 			free(st);
 			errno = EAGAIN;
 			return -1;
 		}
-		pthread_sigmask(SIG_SETMASK, &set, 0);
+		pthread_sigmask(SIG_SETMASK, &set_old, 0);
 	}
 
 	return 0;

--- a/src/signal/sigset.c
+++ b/src/signal/sigset.c
@@ -3,7 +3,7 @@
 void (*sigset(int sig, void (*handler)(int)))(int)
 {
 	struct sigaction sa, sa_old;
-	sigset_t mask;
+	sigset_t mask, mask_old;
 
 	sigemptyset(&mask);
 	if (sigaddset(&mask, sig) < 0)
@@ -12,7 +12,7 @@ void (*sigset(int sig, void (*handler)(int)))(int)
 	if (handler == SIG_HOLD) {
 		if (sigaction(sig, 0, &sa_old) < 0)
 			return SIG_ERR;
-		if (sigprocmask(SIG_BLOCK, &mask, &mask) < 0)
+		if (sigprocmask(SIG_BLOCK, &mask, &mask_old) < 0)
 			return SIG_ERR;
 	} else {
 		sa.sa_handler = handler;
@@ -20,8 +20,8 @@ void (*sigset(int sig, void (*handler)(int)))(int)
 		sigemptyset(&sa.sa_mask);
 		if (sigaction(sig, &sa, &sa_old) < 0)
 			return SIG_ERR;
-		if (sigprocmask(SIG_UNBLOCK, &mask, &mask) < 0)
+		if (sigprocmask(SIG_UNBLOCK, &mask, &mask_old) < 0)
 			return SIG_ERR;
 	}
-	return sigismember(&mask, sig) ? SIG_HOLD : sa_old.sa_handler;
+	return sigismember(&mask_old, sig) ? SIG_HOLD : sa_old.sa_handler;
 }

--- a/src/unistd/ualarm.c
+++ b/src/unistd/ualarm.c
@@ -7,7 +7,7 @@ unsigned ualarm(unsigned value, unsigned interval)
 	struct itimerval it = {
 		.it_interval.tv_usec = interval,
 		.it_value.tv_usec = value
-	};
-	setitimer(ITIMER_REAL, &it, &it);
-	return it.it_value.tv_sec*1000000 + it.it_value.tv_usec;
+	}, it_old;
+	setitimer(ITIMER_REAL, &it, &it_old);
+	return it_old.it_value.tv_sec*1000000 + it_old.it_value.tv_usec;
 }


### PR DESCRIPTION
Cherry-picking commit e0eee3ceefd550724058ffbdf878e9eb06e18f18 from
musllibc mainline. Original comment: The old/new parameters to
pthread_sigmask, sigprocmask, and setitimer are marked restrict, so
passing the same address to both is prohibited. Modify callers of
these functions to use a separate object for each argument.

Signed-off-by: Axel Heider <axelheider@gmx.de>