### PR TITLE
Cmake: fix shell word splitting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,7 +130,7 @@ memoize_add_custom_command(
     # Suppress make output by default. Verbose output can now be achieved by
     # "MAKEFLAGS=V3 ninja". "${MAKEFLAGS:--s}" expands to "-s" if MAKEFLAGS is
     # unset.
-    "MAKEFLAGS=\$\${MAKEFLAGS:--s}"
+    "MAKEFLAGS=\"\$\${MAKEFLAGS:--s}\""
     # TODO: should also pass in the cflags for the CMAKE_BUILD_TYPE ?
     NK_CFLAGS="${compile_options}"
     TARGET=${muslc_arch}


### PR DESCRIPTION
MAKEFLAGS options with spaces as in MAKEFLAGS="-j 2" are incorrectly
interpreted by the shell and result into an error:

```
# setup seL4test ...
$ MAKEFLAGS="-j 2" ninja -j 1
[1/192] Invoking muslc build system
FAILED: apps/sel4test-driver/musllibc/build-temp/stage/lib/libc.a /seL4/test/build_x86/apps/sel4test-driver/musllibc/build-temp/stage/lib/libc.a 
cd /seL4/test/build_x86/apps/sel4test-driver/musllibc && rm -r build-temp && mkdir -p build-temp && /usr/bin/cmake -E env TOOLPREFIX= C_COMPILER=/usr/bin/gcc MAKEFLAGS=${MAKEFLAGS:--s} NK_CFLAGS="-nostdinc -fno-pic -fno-pie -fno-stack-protector -fno-asynchronous-unwind-tables -ftls-model=local-exec -mtls-direct-seg-refs -m64 -march=nehalem -D__KERNEL_64__ " TARGET=x86_64 make -C build-temp -j18 -f /seL4/test/projects/musllibc/Makefile STAGE_DIR=/seL4/test/build_x86/apps/sel4test-driver/musllibc/build-temp/stage SOURCE_DIR=//seL4/test/projects/musllibc && mkdir -p /seL4/test/.sel4_cache/musllibc/45ed0a1e37da30e252ff26e3ce322782 && tar -zcf code.tar.gz -C /seL4/test/build_x86/apps/sel4test-driver/musllibc/build-temp/stage . && mv code.tar.gz /seL4/test/.sel4_cache/musllibc/45ed0a1e37da30e252ff26e3ce322782/
No such file or directory
ninja: build stopped: subcommand failed.
```

Quoting MAKEFLAGS in Cmake prevents word splitting.