### PR TITLE
aarch64_sel4: Use more supported asm directive

### DIFF
--- a/src/internal/aarch64_sel4/syscall.s
+++ b/src/internal/aarch64_sel4/syscall.s
@@ -7,4 +7,4 @@ __syscall:
     br  x9
 
 .hidden __sysinfo
-1:  .dword __sysinfo-1b
+1:  .8byte __sysinfo-1b


### PR DESCRIPTION
Older clang versions, eg clang-8, don't support .dword directives yet. [1]
Instead .8byte means the same thing and appears to be better supported.

[1]: https://github.com/llvm-mirror/llvm/commit/2deb068b06a478f446fdb980628cb2198f1fccfa#diff-6559010013f4d929da731794d1e2ace28a742d7386c12edb972d7dcdd4bfcbb5R250