### PR TITLE
Makefile: update config.mak generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ build_muslc:
 	# Only print output if there's an error as configure is quite noisy
 	# Also need to update the ARCH in the config.mak file configure generates
 	[ "`cat configure_line 2>&1`" != "${configure_line}" ] && \
-		${SOURCE_DIR}/configure ${configure_line} 2>&1 > config.log || cat config.log  && sed -ibak 's/^ARCH = \(.*\)/ARCH = \1_sel4/' config.mak || true
+		${SOURCE_DIR}/configure ${configure_line} 2>&1 > config.log || cat config.log && mv config.mak config.makbak && sed 's/^ARCH = \(.*\)/ARCH = \1_sel4/' config.makbak >> config.mak || true
 	# Store the current configuration
 	echo "${configure_line}" > configure_line
 	# Symlink in the correct Makefile as the configure script doesn't know that we renamed the muslc one


### PR DESCRIPTION
On MacOS build environments, running the "sed -i" command results in a "Permission denied" warning during the build process. This causes musllibc to compile against the stock architecture, instead of the seL4 flavor. The resulting syscall differences cause the rootserver to fault with no explanation why.

This commit creates the config.makbak file instead of relying upon the "sed -i" command to generate it. This fixes the behavior on the MacOS environment without effecting other supported build environments.

Fixes the issue found in https://github.com/seL4/musllibc/issues/20